### PR TITLE
[Refactor] TanStack Query 쿼리 키 계층화 및 관련 코드 수정

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,6 +1,6 @@
+import pluginReact from "eslint-plugin-react";
 import globals from "globals";
 import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -11,6 +11,7 @@ export default [
     ...pluginReact.configs.flat.recommended,
     rules: {
       "react/react-in-jsx-scope": "off",
+      "@typescript-eslint/no-explicit-any": "off",
     },
   },
 ];

--- a/client/src/components/admin/layout/AdminTabs.tsx
+++ b/client/src/components/admin/layout/AdminTabs.tsx
@@ -28,6 +28,7 @@ export const AdminTabs = ({ setLogout }: { setLogout: () => void }) => {
   const [selectedBlog, setSelectedBlog] = useState<SelectedBlogType>({ blogId: 0, blogName: "" });
   const [reason, setReason] = useState("");
   const { searchParam } = useAdminSearchStore();
+
   const {
     data: pendingData,
     isLoading: isPendingLoading,
@@ -74,7 +75,11 @@ export const AdminTabs = ({ setLogout }: { setLogout: () => void }) => {
   const { mutate: rejectMutate } = useAdminReject(onSuccess, onError);
 
   const handleActions = (data: AdminRequest, actions: "accept" | "reject") => {
-    actions === "accept" ? acceptMutate(data) : rejectMutate(data);
+    if (actions === "accept") {
+      acceptMutate(data);
+    } else {
+      rejectMutate(data);
+    }
   };
 
   const handleSelectedBlog = ({ blogName, blogId }: SelectedBlogType) => {
@@ -100,27 +105,17 @@ export const AdminTabs = ({ setLogout }: { setLogout: () => void }) => {
       </div>
     );
 
-  const pendingRss: AdminRssData[] =
+  const filterRssData = (data: AdminRssData[]) =>
     searchParam === ""
-      ? pendingData.data
-      : pendingData.data.filter(
-          (data: AdminRssData) =>
-            data.name.includes(searchParam) || data.userName.includes(searchParam) || data.rssUrl.includes(searchParam)
+      ? data
+      : data.filter(
+          (item) =>
+            item.name.includes(searchParam) || item.userName.includes(searchParam) || item.rssUrl.includes(searchParam)
         );
-  const acceptedRss: AdminRssData[] =
-    searchParam === ""
-      ? acceptedData.data
-      : acceptedData.data.filter(
-          (data: AdminRssData) =>
-            data.name.includes(searchParam) || data.userName.includes(searchParam) || data.rssUrl.includes(searchParam)
-        );
-  const rejectedRss: AdminRssData[] =
-    searchParam === ""
-      ? rejectedData.data
-      : rejectedData.data.filter(
-          (data: AdminRssData) =>
-            data.name.includes(searchParam) || data.userName.includes(searchParam) || data.rssUrl.includes(searchParam)
-        );
+
+  const pendingRss = filterRssData(pendingData?.data || []);
+  const acceptedRss = filterRssData(acceptedData?.data || []);
+  const rejectedRss = filterRssData(rejectedData?.data || []);
 
   return (
     <div>

--- a/client/src/components/chart/Chart.tsx
+++ b/client/src/components/chart/Chart.tsx
@@ -2,30 +2,37 @@ import { lazy, Suspense } from "react";
 
 import ChartSkeleton from "@/components/chart/ChartSkeleton";
 
-import { useChart } from "@/hooks/queries/useChart";
+import { useAllChart, useTodayChart, usePlatformChart } from "@/hooks/queries/useChart";
 
 const BarChartItem = lazy(() => import("@/components/chart/BarChartItem"));
 const PieChartItem = lazy(() => import("@/components/chart/PieChartItem"));
 
 export default function Chart() {
-  const { data, isLoading, error } = useChart();
-  if (!data || isLoading) return <ChartSkeleton />;
-  if (error) return <p>Error loading data</p>;
-  const { chartAll, chartToday, chartPlatform } = data;
+  const { data: chartAll, isLoading: isAllLoading, error: allError } = useAllChart();
+  const { data: chartToday, isLoading: isTodayLoading, error: todayError } = useTodayChart();
+  const { data: chartPlatform, isLoading: isPlatformLoading, error: platformError } = usePlatformChart();
+
+  if (isAllLoading || isTodayLoading || isPlatformLoading) return <ChartSkeleton />;
+  if (allError || todayError || platformError) return <p>Error loading data</p>;
 
   return (
     <div className="p-8">
       <div className="flex">
         <Suspense fallback={<ChartSkeleton />}>
-          <BarChartItem title="전체 조회수" description="전체 조회수 TOP5" data={chartAll.data} color={true} />
+          <BarChartItem title="전체 조회수" description="전체 조회수 TOP5" data={chartAll?.data || []} color={true} />
         </Suspense>
         <Suspense fallback={<ChartSkeleton />}>
-          <BarChartItem title="오늘의 조회수" description="금일 조회수 TOP5" data={chartToday.data} color={false} />
+          <BarChartItem
+            title="오늘의 조회수"
+            description="금일 조회수 TOP5"
+            data={chartToday?.data || []}
+            color={false}
+          />
         </Suspense>
       </div>
       <div>
         <Suspense fallback={<ChartSkeleton />}>
-          <PieChartItem data={chartPlatform.data} title="플랫폼별 블로그 수" />
+          <PieChartItem data={chartPlatform?.data || []} title="플랫폼별 블로그 수" />
         </Suspense>
       </div>
     </div>

--- a/client/src/hooks/queries/useChart.ts
+++ b/client/src/hooks/queries/useChart.ts
@@ -2,35 +2,26 @@ import { chart } from "@/api/services/chart/chart";
 import { ChartResponse, ChartPlatforms } from "@/types/chart";
 import { useQuery } from "@tanstack/react-query";
 
-type ChartType = {
-  chartAll: ChartResponse;
-  chartToday: ChartResponse;
-  chartPlatform: ChartPlatforms;
-};
-
-export const useChart = () => {
-  const { data, isLoading, error } = useQuery<ChartType>({
-    queryKey: ["charts"],
-    queryFn: async (): Promise<ChartType> => {
-      const results = await Promise.allSettled([chart.getAll(), chart.getToday(), chart.getPlatform()]);
-      // 타입별 기본값 지정
-      const chartAll: ChartResponse = results[0].status === "fulfilled" ? results[0].value : { message: "", data: [] };
-
-      const chartToday: ChartResponse =
-        results[1].status === "fulfilled" ? results[1].value : { message: "", data: [] };
-
-      const chartPlatform: ChartPlatforms =
-        results[2].status === "fulfilled" ? results[2].value : { message: "", data: [] };
-
-      return {
-        chartAll,
-        chartToday,
-        chartPlatform,
-      };
-    },
-    refetchInterval: 1000 * 6 * 10,
+export const useAllChart = () =>
+  useQuery<ChartResponse>({
+    queryKey: ["charts", "all"],
+    queryFn: chart.getAll,
+    staleTime: 10 * 60 * 1000,
     retry: 1,
   });
 
-  return { data, isLoading, error };
-};
+export const useTodayChart = () =>
+  useQuery<ChartResponse>({
+    queryKey: ["charts", "today"],
+    queryFn: chart.getToday,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+export const usePlatformChart = () =>
+  useQuery<ChartPlatforms>({
+    queryKey: ["charts", "platform"],
+    queryFn: chart.getPlatform,
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+  });

--- a/client/src/hooks/queries/useChart.ts
+++ b/client/src/hooks/queries/useChart.ts
@@ -1,3 +1,5 @@
+import { ONE_MINUTE } from "@/common/constant";
+
 import { chart } from "@/api/services/chart/chart";
 import { ChartResponse, ChartPlatforms } from "@/types/chart";
 import { useQuery } from "@tanstack/react-query";
@@ -6,7 +8,7 @@ export const useAllChart = () =>
   useQuery<ChartResponse>({
     queryKey: ["charts", "all"],
     queryFn: chart.getAll,
-    staleTime: 10 * 60 * 1000,
+    staleTime: 10 * ONE_MINUTE,
     retry: 1,
   });
 
@@ -14,7 +16,7 @@ export const useTodayChart = () =>
   useQuery<ChartResponse>({
     queryKey: ["charts", "today"],
     queryFn: chart.getToday,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 5 * ONE_MINUTE,
     retry: 1,
   });
 
@@ -22,6 +24,6 @@ export const usePlatformChart = () =>
   useQuery<ChartPlatforms>({
     queryKey: ["charts", "platform"],
     queryFn: chart.getPlatform,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 5 * ONE_MINUTE,
     retry: 1,
   });

--- a/client/src/hooks/queries/useFetchRss.ts
+++ b/client/src/hooks/queries/useFetchRss.ts
@@ -1,23 +1,23 @@
 import { admin } from "@/api/services/admin/rss";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-export const useFetchData = (queryKey: string, queryFn: () => Promise<any>) => {
+export const useFetchData = (queryKey: string[], queryFn: () => Promise<any>) => {
   const queryClient = useQueryClient();
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [queryKey],
+    queryKey,
     queryFn,
     retry: 1,
     refetchInterval: 1000 * 5,
   });
 
   const refetchData = () => {
-    queryClient.invalidateQueries({ queryKey: [queryKey] });
+    queryClient.invalidateQueries({ queryKey });
   };
 
   return { data, isLoading, error, refetchData };
 };
 
-export const useFetchRss = () => useFetchData("adminRss", admin.getRss);
-export const useFetchAccept = () => useFetchData("adminAccept", admin.getAccept);
-export const useFetchReject = () => useFetchData("adminReject", admin.getReject);
+export const useFetchRss = () => useFetchData(["rss", "list"], admin.getRss);
+export const useFetchAccept = () => useFetchData(["rss", "accepted"], admin.getAccept);
+export const useFetchReject = () => useFetchData(["rss", "rejected"], admin.getReject);

--- a/client/src/hooks/queries/useFetchRss.ts
+++ b/client/src/hooks/queries/useFetchRss.ts
@@ -1,4 +1,5 @@
 import { admin } from "@/api/services/admin/rss";
+import { ONE_SECOND } from "@common/constant";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useFetchData = (queryKey: string[], queryFn: () => Promise<any>) => {
@@ -8,7 +9,7 @@ export const useFetchData = (queryKey: string[], queryFn: () => Promise<any>) =>
     queryKey,
     queryFn,
     retry: 1,
-    refetchInterval: 1000 * 5,
+    refetchInterval: 5 * ONE_SECOND,
   });
 
   const refetchData = () => {

--- a/client/src/hooks/queries/useSearch.ts
+++ b/client/src/hooks/queries/useSearch.ts
@@ -5,6 +5,7 @@ import { debounce } from "@/utils/debounce";
 // import axios from "axios"; //mockAPI사용시
 import { getSearch } from "@/api/services/search";
 import { SearchRequest } from "@/types/search";
+import { ONE_MINUTE } from "@common/constant";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useSearch = ({ query, filter, page, pageSize }: SearchRequest) => {
@@ -18,14 +19,16 @@ export const useSearch = ({ query, filter, page, pageSize }: SearchRequest) => {
     handler(query);
 
     return () => {
-      handler.cancel && handler.cancel();
+      if (handler.cancel) {
+        handler.cancel();
+      }
     };
   }, [query]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["getSearch", debouncedQuery, filter, page, pageSize],
     queryFn: () => getSearch({ query, filter, page, pageSize }),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 5 * ONE_MINUTE,
     retry: 1,
   });
   const refetchSearch = () => {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,9 +1,8 @@
-// commitlint.config.js
 module.exports = {
   parserPreset: {
     parserOpts: {
-      headerPattern: /^(\S+)\s\[(\w+)\]:\s(.+)$/u,
-      headerCorrespondence: ["emoji", "type", "subject"],
+      headerPattern: /^(\w+)\(#(\d+)\):\s(.+)$/u, // feat(#n): 설명 형식
+      headerCorrespondence: ["type", "issue", "subject"],
     },
   },
   rules: {
@@ -29,13 +28,13 @@ module.exports = {
     {
       rules: {
         "header-pattern": ({ header }, when = "always") => {
-          const regex = /^(\S+)\s(\w+):\s(.+)$/u;
+          const regex = /^(\w+)\(#(\d+)\):\s(.+)$/u;
           const pass = regex.test(header);
           return [
             pass,
             `커밋 메시지는 다음 형식을 따라야 합니다:\n` +
-              `[이모지] [타입]: [설명]\n` +
-              `예: ✨ feat: 기능 설명`,
+              `feat(#3): 설명\n` +
+              `예: feat(#42): 새로운 기능 추가`,
           ];
         },
       },

--- a/feed-crawler/src/common/constant.ts
+++ b/feed-crawler/src/common/constant.ts
@@ -3,3 +3,4 @@ export const redisConstant = {
   FEED_RECENT_ALL_KEY: "feed:recent:*",
 };
 export const ONE_MINUTE = 60 * 1000;
+export const ONE_SECOND = 1000;

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -1,6 +1,7 @@
 import logger from "./common/logger.js";
 import { feedCrawler } from "./feed-crawler.js";
 import { mysqlConnection } from "./common/mysql-access.js";
+import { ONE_SECOND } from "@common/constant";
 
 async function runCrawler() {
   logger.info("==========작업 시작==========");
@@ -9,7 +10,7 @@ async function runCrawler() {
   const endTime = Date.now();
   const executionTime = endTime - startTime;
   await mysqlConnection.end();
-  logger.info(`실행 시간: ${executionTime / 1000}seconds`);
+  logger.info(`실행 시간: ${executionTime / ONE_SECOND}seconds`);
   logger.info("==========작업 완료==========");
 }
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   Resolves: #3 

### 소주제 1. 쿼리 키 계층화

- 기존의 단일 레벨 쿼리 키로 인해 데이터 상태 구분과 갱신 효율성이 부족했습니다.

- 이에 따라 쿼리 키를 계층화하여 데이터를 명확히 구분하고, 무효화와 갱신 로직을 최적화했습니다.

```
// 기존
["adminRss"], ["adminAccept"], ["adminReject"]

// 변경
["rss", "list"], ["rss", "accepted"], ["rss", "rejected"]
```

### 소주제 2. 캐싱 전략 개선

- 차트 데이터는 성격별로 쿼리 키를 계층화하고 캐싱 설정(`staleTime`, `gcTime`)을 데이터 특성에 맞게 조정했습니다.

- RSS 데이터는 관리자 작업 중 실시간 갱신을 위해 `refetchInterval`을 추가했습니다.

# 📋 작업 내용 요약

### RSS 데이터

- 쿼리 키 계층화 및 무효화 로직 수정

### 차트 데이터

- 쿼리 키를 세분화(["charts", "all"], ["charts", "today"], ["charts", "platform"])

### ESLint 및 커밋 린트 수정

