### PR TITLE
[Refactor] staleTime 매직 넘버 constant화

### DIFF
--- a/client/src/constants/time.ts
+++ b/client/src/constants/time.ts
@@ -1,0 +1,2 @@
+export const ONE_MINUTE = 60 * 1000;
+export const ONE_SECOND = 1000;

--- a/client/src/hooks/queries/useChart.ts
+++ b/client/src/hooks/queries/useChart.ts
@@ -1,4 +1,4 @@
-import { ONE_MINUTE } from "@/common/constant";
+import { ONE_MINUTE } from "@/constants/time";
 
 import { chart } from "@/api/services/chart/chart";
 import { ChartResponse, ChartPlatforms } from "@/types/chart";

--- a/client/src/hooks/queries/useFetchRss.ts
+++ b/client/src/hooks/queries/useFetchRss.ts
@@ -1,5 +1,6 @@
+import { ONE_SECOND } from "@/constants/time";
+
 import { admin } from "@/api/services/admin/rss";
-import { ONE_SECOND } from "@common/constant";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useFetchData = (queryKey: string[], queryFn: () => Promise<any>) => {

--- a/client/src/hooks/queries/useSearch.ts
+++ b/client/src/hooks/queries/useSearch.ts
@@ -1,11 +1,12 @@
 import { useState, useEffect } from "react";
 
+import { ONE_MINUTE } from "@/constants/time";
+
 import { debounce } from "@/utils/debounce";
 
 // import axios from "axios"; //mockAPI사용시
 import { getSearch } from "@/api/services/search";
 import { SearchRequest } from "@/types/search";
-import { ONE_MINUTE } from "@common/constant";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useSearch = ({ query, filter, page, pageSize }: SearchRequest) => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   resolves: #6 

# 📋 작업 내용

- `refactor-web41-denannu/client/src/hooks/queries`에서 사용되는 시간 관련 매직 넘버가 `refactor-web41-denannu/feed-crawler` 디렉토리에 선언되어 있었고, 선언부와 사용부의 거리를 줄이기 위해서 `client` 디렉토리에 위치하도록 만들어야겠다고 생각했습니다.

-  이에 따라 staleTime 관련 매직 넘버를 `refactor-web41-denannu/client/src/utils/time.ts`에 저장하여 사용하도록 수정하였습니다.

