### PR TITLE
[Feat] RSS 등록 폼에 상태 저장 기능 추가

### DIFF
--- a/client/src/components/RssRegistration/RssRegistrationModal.tsx
+++ b/client/src/components/RssRegistration/RssRegistrationModal.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import FormInput from "@/components/RssRegistration/FormInput";
-import { PlatformSelector } from "@/components/RssRegistration/PlatformSelector.tsx";
+import { PlatformSelector } from "@/components/RssRegistration/PlatformSelector";
 import { RssUrlInput } from "@/components/RssRegistration/RssUrlInput";
 import Alert from "@/components/common/Alert";
 import { Button } from "@/components/ui/button";
@@ -14,11 +14,12 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-import { useRssRegistrationForm } from "@/hooks/common/useRssRegistrationForm.ts";
-import { useRegisterRss } from "@/hooks/queries/useRegisterRss.ts";
+import { useRssRegistrationForm } from "@/hooks/common/useRssRegistrationForm";
+import { useRegisterRss } from "@/hooks/queries/useRegisterRss";
 
-import { AlertType } from "@/types/alert.ts";
-import { RegisterRss } from "@/types/rss.ts";
+import { useRegisterModalStore } from "@/store/useRegisterModalStore";
+import { AlertType } from "@/types/alert";
+import { RegisterRss } from "@/types/rss";
 
 export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: () => void; rssOpen: boolean }) {
   const [alertOpen, setAlertOpen] = useState<AlertType>({ title: "", content: "", isOpen: false });
@@ -28,7 +29,7 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
     () => {
       setAlertOpen({
         title: "RSS 요청 성공!",
-        content: "관리자가 검토후 처리 결과를 입력해주신 메일을 통해 전달드릴 예정이에요!",
+        content: "관리자가 검토 후 처리 결과를 입력해주신 메일을 통해 전달드릴 예정이에요!",
         isOpen: true,
       });
     },
@@ -40,6 +41,16 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
       });
     }
   );
+
+  useEffect(() => {
+    if (rssOpen) {
+      const store = useRegisterModalStore.getState();
+      store.setRssUrlValid(/^(https?:\/\/[^\s]+)$/i.test(store.rssUrl));
+      store.setBloggerNameValid(store.bloggerName.trim().length > 0);
+      store.setUserNameValid(store.userName.trim().length > 0);
+      store.setEmailValid(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(store.email));
+    }
+  }, [rssOpen]);
 
   const handleAlertClose = () => {
     setAlertOpen({ title: "", content: "", isOpen: false });

--- a/client/src/components/RssRegistration/RssRegistrationModal.tsx
+++ b/client/src/components/RssRegistration/RssRegistrationModal.tsx
@@ -23,6 +23,8 @@ import { RegisterRss } from "@/types/rss";
 
 export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: () => void; rssOpen: boolean }) {
   const [alertOpen, setAlertOpen] = useState<AlertType>({ title: "", content: "", isOpen: false });
+  const [showMessage, setShowMessage] = useState(false);
+  const [messageText, setMessageText] = useState("");
 
   const { platform, values, handlers, formState } = useRssRegistrationForm();
   const { mutate } = useRegisterRss(
@@ -45,6 +47,14 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
   useEffect(() => {
     if (rssOpen) {
       const store = useRegisterModalStore.getState();
+      const hasPreviousData =
+        store.bloggerName.trim() !== "" || store.userName.trim() !== "" || store.email.trim() !== "";
+      if (hasPreviousData) {
+        setMessageText("등록 중이던 데이터를 불러왔습니다.");
+        setShowMessage(true);
+        setTimeout(() => setShowMessage(false), 3000);
+      }
+
       store.setRssUrlValid(/^(https?:\/\/[^\s]+)$/i.test(store.rssUrl));
       store.setBloggerNameValid(store.bloggerName.trim().length > 0);
       store.setUserNameValid(store.userName.trim().length > 0);
@@ -82,6 +92,7 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
         <div className="space-y-6">
           <PlatformSelector platform={platform} onPlatformChange={handlers.handlePlatformChange} />
           <RssUrlInput platform={platform} value={values.urlUsername} onChange={handlers.handleUsernameChange} />
+          {showMessage && <div className="mb-4 text-sm text-primary font-medium">{messageText}</div>}
 
           <div className="space-y-4">
             <FormInput

--- a/client/src/store/useRegisterModalStore.ts
+++ b/client/src/store/useRegisterModalStore.ts
@@ -1,31 +1,28 @@
 import { create } from "zustand";
 
+import { persist } from "zustand/middleware";
+
 interface RegisterModalState {
-  //Form Value
   rssUrl: string;
   bloggerName: string;
   userName: string;
   email: string;
 
-  //Vaildation state
   rssUrlValid: boolean;
   bloggerNameValid: boolean;
   userNameValid: boolean;
   emailValid: boolean;
 
-  //Setting Form Value
   setRssUrl: (url: string) => void;
   setBloggerName: (name: string) => void;
   setUserName: (name: string) => void;
   setEmail: (email: string) => void;
 
-  //Setting Vaildation State
   setRssUrlValid: (valid: boolean) => void;
   setBloggerNameValid: (valid: boolean) => void;
   setUserNameValid: (valid: boolean) => void;
   setEmailValid: (valid: boolean) => void;
 
-  //Vaildation Handler
   handleInputChange: (
     value: string,
     setValue: (value: string) => void,
@@ -33,58 +30,63 @@ interface RegisterModalState {
     validate: (value: string) => boolean
   ) => void;
 
-  //Other
   resetInputs: () => void;
   isFormValid: () => boolean;
 }
 
-export const useRegisterModalStore = create<RegisterModalState>((set, get) => ({
-  // Initial Form Values
-  rssUrl: "",
-  bloggerName: "",
-  userName: "",
-  email: "",
-
-  // Initial Validation States
-  rssUrlValid: false,
-  bloggerNameValid: false,
-  userNameValid: false,
-  emailValid: false,
-
-  // Setters Form Values
-  setRssUrl: (url) => set({ rssUrl: url }),
-  setBloggerName: (name) => set({ bloggerName: name }),
-  setUserName: (name) => set({ userName: name }),
-  setEmail: (email) => set({ email }),
-
-  // Setters Validation States
-  setRssUrlValid: (valid) => set({ rssUrlValid: valid }),
-  setBloggerNameValid: (valid) => set({ bloggerNameValid: valid }),
-  setUserNameValid: (valid) => set({ userNameValid: valid }),
-  setEmailValid: (valid) => set({ emailValid: valid }),
-
-  // Reset
-  resetInputs: () =>
-    set({
+export const useRegisterModalStore = create(
+  persist<RegisterModalState>(
+    (set, get) => ({
       rssUrl: "",
       bloggerName: "",
       userName: "",
       email: "",
+
       rssUrlValid: false,
       bloggerNameValid: false,
       userNameValid: false,
       emailValid: false,
+
+      setRssUrl: (url) => set({ rssUrl: url }),
+      setBloggerName: (name) => set({ bloggerName: name }),
+      setUserName: (name) => set({ userName: name }),
+      setEmail: (email) => set({ email }),
+
+      setRssUrlValid: (valid) => set({ rssUrlValid: valid }),
+      setBloggerNameValid: (valid) => set({ bloggerNameValid: valid }),
+      setUserNameValid: (valid) => set({ userNameValid: valid }),
+      setEmailValid: (valid) => set({ emailValid: valid }),
+
+      resetInputs: () =>
+        set({
+          rssUrl: "",
+          bloggerName: "",
+          userName: "",
+          email: "",
+          rssUrlValid: false,
+          bloggerNameValid: false,
+          userNameValid: false,
+          emailValid: false,
+        }),
+
+      isFormValid: () => {
+        const state = get();
+        return state.rssUrlValid && state.bloggerNameValid && state.userNameValid && state.emailValid;
+      },
+
+      handleInputChange: (value, setValue, setValid, validate) => {
+        setValue(value);
+        setValid(validate(value));
+      },
     }),
-
-  // Check Form Vaildation
-  isFormValid: () => {
-    const state = get();
-    return state.rssUrlValid && state.bloggerNameValid && state.userNameValid && state.emailValid;
-  },
-
-  // Handle input change with validation
-  handleInputChange: (value, setValue, setValid, validate) => {
-    setValue(value);
-    setValid(validate(value));
-  },
-}));
+    {
+      name: "register-modal-storage",
+      partialize: (state) => ({
+        rssUrl: state.rssUrl,
+        bloggerName: state.bloggerName,
+        userName: state.userName,
+        email: state.email,
+      }),
+    }
+  )
+);

--- a/client/src/store/useRegisterModalStore.ts
+++ b/client/src/store/useRegisterModalStore.ts
@@ -82,7 +82,6 @@ export const useRegisterModalStore = create(
     {
       name: "register-modal-storage",
       partialize: (state) => ({
-        rssUrl: state.rssUrl,
         bloggerName: state.bloggerName,
         userName: state.userName,
         email: state.email,


### PR DESCRIPTION
# 🔨 테스크

RSS 등록 폼에 상태 저장 기능을 추가하고, 이를 불러왔을 때
사용자에게 표시하도록 함

### Issue

-   resolves #8 

# 📋 작업 내용

### 배경

- Denannu의 RSS 등록 폼은 사용자가 RSS URL을 입력하는 과정에서 새로고침이나 탭 이동 후 재시작 시 입력 데이터가 초기화되는 문제가 있었습니다. 

- 특히, RSS URL이 사용자에게 생소한 값으로, 창을 여러 번 이동하며 입력하는 경우가 많아 이러한 불편함이 자주 발생했습니다. 이로 인해 입력 작업이 반복되며 사용자 이탈 가능성이 우려되었습니다.

### 수행 작업

**폼 데이터 persist 도입**

```ts
//useRegisterModalStore.ts:

export const useRegisterModalStore = create(
  persist<RegisterModalState>(
    (set, get) => ({
      rssUrl: "",
      bloggerName: "",
      userName: "",
      email: "",
      (중략)
    }),
    {
      name: "register-modal-storage",
      partialize: (state) => ({
        bloggerName: state.bloggerName,
        userName: state.userName,
        email: state.email,
      }),
    }
  )
);
```

Zustand의 persist 미들웨어를 활용하여 폼 데이터를 로컬 스토리지에 저장하고, 새로고침이나 탭 재시작 후에도 입력 데이터를 복구하도록 구현했습니다.

**유효성 검사 로직 강화**

```ts
//RssRegistrationModal.tsx

useEffect(() => {
  if (rssOpen) {
    const store = useRegisterModalStore.getState();
    store.setRssUrlValid(/^(https?:\/\/[^\s]+)$/i.test(store.rssUrl));
    store.setBloggerNameValid(store.bloggerName.trim().length > 0);
    store.setUserNameValid(store.userName.trim().length > 0);
    store.setEmailValid(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(store.email));
    const hasPreviousData =
      store.bloggerName.trim() !== "" ||
      store.userName.trim() !== "" ||
      store.email.trim() !== "";
    }
  }
}, [rssOpen]);
```

폼을 열 때 저장된 데이터의 유효성을 검토하여 등록 버튼이 활성화되도록 개선했습니다.

**이전 데이터 복구 알림 기능 추가**

```ts
//RssRegistrationModal.tsx

if (hasPreviousData) {
      setMessageText("이전 등록 데이터를 불러왔습니다.");
      setShowMessage(true);
      setTimeout(() => setShowMessage(false), 3000);
```

이전 데이터가 복구될 경우 사용자에게 메시지로 이를 알리는 기능을 추가하여 직관성을 향상시켰습니다.


# 📷 스크린 샷

https://github.com/user-attachments/assets/4eabd5dd-b8bf-4e39-8810-2eb825ca909a


