### PR TITLE
[Fix] Zustand persist 의 partialize 옵션 사용 시 발생한 TypeScript 타입 오류 해결

### DIFF
--- a/client/src/components/RssRegistration/RssRegistrationModal.tsx
+++ b/client/src/components/RssRegistration/RssRegistrationModal.tsx
@@ -55,7 +55,7 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
         setTimeout(() => setShowMessage(false), 3000);
       }
 
-      store.setRssUrlValid(/^(https?:\/\/[^\s]+)$/i.test(store.rssUrl));
+      store.setRssUrlValid(/^(https?:\/\/[^\s]+)$/i.test(store.rssUrl || ""));
       store.setBloggerNameValid(store.bloggerName.trim().length > 0);
       store.setUserNameValid(store.userName.trim().length > 0);
       store.setEmailValid(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(store.email));
@@ -70,7 +70,7 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
 
   const handleRegister = () => {
     const data: RegisterRss = {
-      rssUrl: values.rssUrl,
+      rssUrl: values.rssUrl || "",
       blog: values.bloggerName,
       name: values.userName,
       email: values.email,

--- a/client/src/hooks/common/useRssRegistrationForm.ts
+++ b/client/src/hooks/common/useRssRegistrationForm.ts
@@ -29,7 +29,7 @@ export const useRssRegistrationForm = () => {
 
   const getUsernameFromUrl = () => {
     const { prefix, suffix } = PLATFORMS[platform];
-    return store.rssUrl.replace(prefix, "").replace(suffix, "");
+    return (store.rssUrl || "").replace(prefix, "").replace(suffix, "");
   };
 
   return {

--- a/client/src/store/useRegisterModalStore.ts
+++ b/client/src/store/useRegisterModalStore.ts
@@ -34,8 +34,8 @@ interface RegisterModalState {
   isFormValid: () => boolean;
 }
 
-export const useRegisterModalStore = create(
-  persist<RegisterModalState>(
+export const useRegisterModalStore = create<RegisterModalState>()(
+  persist(
     (set, get) => ({
       rssUrl: "",
       bloggerName: "",


### PR DESCRIPTION
# 🔨 테스크

Zustand persist의 partialize 옵션 사용으로 인한 빌드 에러 해결

### Issue

-   resolves #12 

# 📋 작업 내용

-   Zustand persist 미들웨어의 partialize 옵션 사용 시 발생한 TypeScript 타입 오류를 해결했습니다.

- partialize가 반환하는 데이터 구조가 RegisterModalState와 일치하지 않아 발생한 문제를 수정했습니다.

- 반환 타입을 Partial<RegisterModalState>로 명시하고, 로컬 스토리지에 필요한 데이터(bloggerName, userName, email)만 저장되도록 변경했습니다.

- 상태 초기화 로직을 개선하고, rssUrl에 기본값("")을 설정하여 잠재적인 undefined 에러를 방지했습니다.

- 빌드가 정상적으로 이루어지는 것을 확인했습니다.

# 📷 스크린 샷

![스크린샷 2025-01-20 오후 2 39 52](https://github.com/user-attachments/assets/ab6b5db3-bb65-4fae-99b4-792e7fed70b3)

