### PR TITLE
[Refactor] 서버 배포 CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+**/node_modules
+dist

--- a/.github/workflows/deploy_client.yml
+++ b/.github/workflows/deploy_client.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "client/**"
+      - 'client/**'
   workflow_dispatch: # 수동 실행을 허용하는 이벤트
 
 jobs:
@@ -25,5 +25,6 @@ jobs:
             cd /refactor-web41-denannu
             git pull origin main
             cd client/
+            echo "${{ secrets.ENV_FE}}" > .env
 
             docker compose up -d --build nginx

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "server/**"
+      - 'server/**'
   workflow_dispatch: # 수동 실행을 허용하는 이벤트
 
 jobs:
@@ -24,6 +24,10 @@ jobs:
 
             cd /refactor-web41-denannu
             git pull origin main
+
+            echo "${{ secrets.REDIS_CONF }}" > redis.conf
+            docker compose up -d --build redis
+
             cd server/
 
             mkdir -p configs

--- a/client/src/api/instance.ts
+++ b/client/src/api/instance.ts
@@ -6,7 +6,7 @@ export const api = axios.create({
 });
 
 export const axiosInstance = axios.create({
-  baseURL: "https://denamu.site",
+  baseURL: import.meta.env.VITE_BASE_URL,
   timeout: 10000,
   withCredentials: true,
 });

--- a/client/src/hooks/queries/useTrendingPosts.ts
+++ b/client/src/hooks/queries/useTrendingPosts.ts
@@ -13,7 +13,7 @@ export const useTrendingPosts = () => {
   });
 
   useEffect(() => {
-    const eventSource = new EventSource("https://denamu.site/api/feed/trend/sse");
+    const eventSource = new EventSource(`${import.meta.env.VITE_BASE_URL}/api/feed/trend/sse`);
 
     eventSource.onmessage = (event) => {
       try {

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 
 import { ChatType } from "@/types/chat";
 
-const CHAT_SERVER_URL = "https://denamu.site";
+const CHAT_SERVER_URL = import.meta.env.VITE_BASE_URL;
 
 interface ChatStore {
   chatHistory: ChatType[];

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
       context: ./
       dockerfile: dockerfile.nginx
     ports:
-      - "80:80"
-      - "443:443"
+      - '80:80'
+      - '443:443'
     container_name: nginx
     volumes:
       - /etc/letsencrypt:/etc/letsencrypt:ro
@@ -28,6 +28,9 @@ services:
   redis:
     image: redis:7.4.1
     container_name: redis
+    volumes:
+      - ./redis.conf:/usr/local/etc/redis/redis.conf
+    command: ['redis-server', '/usr/local/etc/redis/redis.conf']
     networks:
       - refact41-denannu
 

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -1,17 +1,17 @@
-import logger from "./common/logger.js";
-import { feedCrawler } from "./feed-crawler.js";
-import { mysqlConnection } from "./common/mysql-access.js";
-import { ONE_SECOND } from "@common/constant";
+import logger from './common/logger.js';
+import { feedCrawler } from './feed-crawler.js';
+import { mysqlConnection } from './common/mysql-access.js';
+import { ONE_SECOND } from './common/constant';
 
 async function runCrawler() {
-  logger.info("==========작업 시작==========");
+  logger.info('==========작업 시작==========');
   const startTime = Date.now();
   await feedCrawler.start();
   const endTime = Date.now();
   const executionTime = endTime - startTime;
   await mysqlConnection.end();
   logger.info(`실행 시간: ${executionTime / ONE_SECOND}seconds`);
-  logger.info("==========작업 완료==========");
+  logger.info('==========작업 완료==========');
 }
 
 runCrawler();


### PR DESCRIPTION
# 🔨 테스크
- 서버 배포를 위한 CICD 설정 추가

### Issue

-   close {#15}

# 📋 작업 내용

- 서버 URL을 .env에서 관리하도록 수정
  - 기존에 하드코딩된 url을 제거하고, `import.meta.env.VITE_BASE_URL`을 사용하도록 변경
  - local에서 사용할 때는 client 폴더에 .env 파일 생성 후 `VITE_BASE_URL=http://localhost`와 같이 사용할 url 작성해주면 됩니다.
- feed-crawler에서 @common/constant를 ./common/constant로 수정
  - @common/constant 경로가 별도로 설정되지 않아 빌드 후 실행 시 오류가 발생하던 문제 해결
  - 상대 경로인 `./common/constant`로 변경하여 정상적으로 동작하도록 수정
- CI/CD 설정 개선
  - `.dockerignore` 파일 생성
  - `docker-compose` 파일에 Redis 설정 추가
  - `Dockerfile.nginx`에서 client 빌드 시 `.env` 추가
  - `Dockerfile.server`에서 Redis 실행 명령 추가