### PR TITLE
[Refactor] deploy 파일의 잘못된 폴더명 변경

### DIFF
--- a/.github/workflows/deploy_client.yml
+++ b/.github/workflows/deploy_client.yml
@@ -22,9 +22,9 @@ jobs:
           port: ${{ secrets.PORT }}
           script: |
 
-            cd /refactor-web41-denannu
+            cd refactor-web41-Denannu
             git pull origin main
-            cd client/
+            cd client
             echo "${{ secrets.ENV_FE}}" > .env
 
             docker compose up -d --build nginx

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -22,15 +22,14 @@ jobs:
           port: ${{ secrets.PORT }}
           script: |
 
-            cd /refactor-web41-denannu
+            cd refactor-web41-Denannu
             git pull origin main
 
             echo "${{ secrets.REDIS_CONF }}" > redis.conf
             docker compose up -d --build redis
 
-            cd server/
+            cd server
 
-            mkdir -p configs
             echo "${{ secrets.ENV_BE_DB}}" > configs/.env.db.production
 
             cd ..


### PR DESCRIPTION
# 🔨 테스크
- 서버의 폴더명과 deploy의 폴더명이 달라 변경
  - cd refactor-web41-denannu에서 cd refactor-web41-Denannu로 변경
