### PR TITLE
[Fix] 커서 데이터 누락 문제 해결

### DIFF
--- a/client/src/hooks/queries/useSearch.ts
+++ b/client/src/hooks/queries/useSearch.ts
@@ -6,10 +6,11 @@ import { debounce } from "@/utils/debounce";
 
 import { getSearch } from "@/api/services/search";
 import { useSearchStore } from "@/store/useSearchStore";
-import { SearchRequest, SearchResponse, CursorData } from "@/types/search";
-import { useQuery, useQueryClient, UseQueryOptions } from "@tanstack/react-query";
+import { SearchRequest, SearchResponse } from "@/types/search";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-export const useSearch = ({ query, filter, page, pageSize, cursor }: SearchRequest & { cursor?: CursorData }) => {
+export const useSearch = (params: SearchRequest) => {
+  const { query, filter, page, pageSize, cursor } = params;
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const queryClient = useQueryClient();
   const { setCursor } = useSearchStore();
@@ -28,22 +29,22 @@ export const useSearch = ({ query, filter, page, pageSize, cursor }: SearchReque
     };
   }, [query]);
 
-  const queryOptions: UseQueryOptions<SearchResponse, Error> = {
-    queryKey: ["getSearch", debouncedQuery, filter, page, pageSize, cursor],
-    queryFn: () =>
-      getSearch({
+  const { data, isLoading, error } = useQuery<SearchResponse, Error>({
+    queryKey: ["getSearch", debouncedQuery, filter, page, pageSize, cursor ? JSON.stringify(cursor) : null],
+    queryFn: async () => {
+      const response = await getSearch({
         query: debouncedQuery,
         filter,
         page,
         pageSize,
         cursor,
-      }),
+      });
+      return response;
+    },
     staleTime: 5 * ONE_MINUTE,
     retry: 1,
     enabled: debouncedQuery.length > 0,
-  };
-
-  const { data, isLoading, error } = useQuery<SearchResponse, Error>(queryOptions);
+  });
 
   useEffect(() => {
     if (data?.data?.cursor) {
@@ -52,8 +53,13 @@ export const useSearch = ({ query, filter, page, pageSize, cursor }: SearchReque
   }, [data, setCursor]);
 
   const refetchSearch = () => {
+    const queryKey = ["getSearch", debouncedQuery, filter, page, pageSize];
+    if (cursor) {
+      queryKey.push(JSON.stringify(cursor));
+    }
     queryClient.invalidateQueries({
-      queryKey: ["getSearch", debouncedQuery, filter, page, pageSize],
+      queryKey: queryKey,
+      refetchType: "active",
     });
   };
 

--- a/client/src/store/useSearchStore.ts
+++ b/client/src/store/useSearchStore.ts
@@ -6,8 +6,8 @@ interface SearchState {
   currentFilter: FilterType;
   searchParam: string;
   page: number;
-  preData: CursorData["preData"] | null;
-  nextIndex: CursorData["nextIndex"] | null;
+  preIndex: CursorData["preIndex"];
+  nextIndex: CursorData["nextIndex"];
   setFilter: (filter: FilterType) => void;
   setSearchParam: (param: string) => void;
   setPage: (page: number) => void;
@@ -26,24 +26,32 @@ export const useSearchStore = create<SearchState>((set) => ({
   currentFilter: "title",
   searchParam: "",
   page: 1,
-  preData: null,
+  preIndex: null,
   nextIndex: null,
-  setFilter: (currentFilter) => set({ currentFilter }),
-  setSearchParam: (param) =>
+  setFilter: (currentFilter) => {
+    set({ currentFilter });
+  },
+  setSearchParam: (param) => {
     set({
       searchParam: param,
-      preData: null,
+      preIndex: null,
       nextIndex: null,
       page: 1,
-    }),
-  setPage: (page) => set({ page }),
-  setCursor: (cursor) =>
-    set({
-      preData: cursor?.preData || null,
-      nextIndex: cursor?.nextIndex || null,
-    }),
+    });
+  },
+  setPage: (page) => {
+    set({ page });
+  },
+  setCursor: (cursor) => {
+    if (!cursor) return;
+    const newState = {
+      preIndex: cursor.preIndex || null,
+      nextIndex: cursor.nextIndex || null,
+    };
+    set(newState);
+  },
   resetPage: () => set({ page: 1 }),
-  resetParam: () => set({ searchParam: "", preData: null, nextIndex: null }),
+  resetParam: () => set({ searchParam: "", preIndex: null, nextIndex: null }),
   resetFilter: () => set({ currentFilter: "title" }),
 }));
 

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -8,7 +8,7 @@ export interface SearchResult {
 
 export interface CursorData {
   curPage: number;
-  preData?: {
+  preIndex?: {
     feedId: number;
     createdAt: string;
   };


### PR DESCRIPTION
# 🔨 테스크
* 커서 기반 페이지네이션에서 cursor 데이터가 API 요청에 포함되지 않는 문제

### Issue
* resolves:  #23 

# 📋 작업 내용
### 1. `preData` → `preIndex`로 이름 변경

* 백엔드 API 응답에서 `preData`로 잘못 명명된 필드를 `preIndex`로 수정하였습니다
* 프론트엔드의 타입 정의와 관련 로직도 함께 수정하였습니다

```ts
// types/search.ts
interface Cursor {
  curPage: number;
  preIndex: IndexInfo | null;  // preData → preIndex
  nextIndex: IndexInfo | null;
}

// store/useSearchStore.ts
interface SearchState {
  preIndex: IndexInfo | null;  // preData → preIndex
  nextIndex: IndexInfo | null;
  // ...
}
```

### 2. SearchPages 컴포넌트 수정

* `prefetchQuery`에서 실제 API를 호출하도록 수정하였습니다

```typescript
queryClient.prefetchQuery({
  queryKey: ["getSearch", searchParam, currentFilter, page + 1, 5],
  queryFn: () => getSearch({
    query: searchParam,
    filter: currentFilter,
    page: page + 1,
    pageSize: 5,
    cursor,
  }),
});
```

### 3. `useSearch` 훅 수정
* queryKey에 cursor 정보를 포함시켜 캐싱이 제대로 동작하도록 수정하였습니다
* cursor가 없는 경우 null을 사용하여 queryKey의 일관성을 유지하도록 하였습니다

```typescript
const { data, isLoading, error } = useQuery<SearchResponse, Error>({
  queryKey: ["getSearch", debouncedQuery, filter, page, pageSize, 
    cursor ? JSON.stringify(cursor) : null],
  queryFn: async () => {
    const response = await getSearch({
      query: debouncedQuery,
      filter,
      page,
      pageSize,
      cursor,
    });
    return response;
  },
});
```

### 결과 확인
* 페이지 이동 시 cursor 정보가 정상적으로 포함된 API 요청 확인
* TanStack Query의 캐싱이 정상 동작하여 중복 요청 문제 해결

이를 통해 커서 기반 페이지네이션이 의도한 대로 작동하도록 수정했습니다.