### PR TITLE
[Fix] preIndex, nextIndex의 디폴트 값을 undefined로 통일하여 빌드 에러 해결

### DIFF
--- a/client/src/components/search/searchPages/SearchPages.tsx
+++ b/client/src/components/search/searchPages/SearchPages.tsx
@@ -26,7 +26,7 @@ export default function SearchPages({ totalPages }: { totalPages: number }) {
           const cursor = {
             curPage: page,
             preIndex,
-            nextIndex: null,
+            nextIndex: undefined,
           };
           setPage(page - 1);
           queryClient.prefetchQuery({
@@ -48,7 +48,7 @@ export default function SearchPages({ totalPages }: { totalPages: number }) {
         if (nextIndex) {
           const cursor = {
             curPage: page,
-            preIndex: null,
+            preIndex: undefined,
             nextIndex,
           };
           setPage(page + 1);

--- a/client/src/store/useSearchStore.ts
+++ b/client/src/store/useSearchStore.ts
@@ -11,7 +11,7 @@ interface SearchState {
   setFilter: (filter: FilterType) => void;
   setSearchParam: (param: string) => void;
   setPage: (page: number) => void;
-  setCursor: (cursor: CursorData | null) => void;
+  setCursor: (cursor: CursorData | undefined) => void;
   resetPage: () => void;
   resetParam: () => void;
   resetFilter: () => void;
@@ -26,16 +26,16 @@ export const useSearchStore = create<SearchState>((set) => ({
   currentFilter: "title",
   searchParam: "",
   page: 1,
-  preIndex: null,
-  nextIndex: null,
+  preIndex: undefined,
+  nextIndex: undefined,
   setFilter: (currentFilter) => {
     set({ currentFilter });
   },
   setSearchParam: (param) => {
     set({
       searchParam: param,
-      preIndex: null,
-      nextIndex: null,
+      preIndex: undefined,
+      nextIndex: undefined,
       page: 1,
     });
   },
@@ -45,13 +45,13 @@ export const useSearchStore = create<SearchState>((set) => ({
   setCursor: (cursor) => {
     if (!cursor) return;
     const newState = {
-      preIndex: cursor.preIndex || null,
-      nextIndex: cursor.nextIndex || null,
+      preIndex: cursor.preIndex || undefined,
+      nextIndex: cursor.nextIndex || undefined,
     };
     set(newState);
   },
   resetPage: () => set({ page: 1 }),
-  resetParam: () => set({ searchParam: "", preIndex: null, nextIndex: null }),
+  resetParam: () => set({ searchParam: "", preIndex: undefined, nextIndex: undefined }),
   resetFilter: () => set({ currentFilter: "title" }),
 }));
 


### PR DESCRIPTION
# 🔨 테스크

- `preIndex`, `nextIndex`의 디폴트 값을 `undefined`로 통일하여 빌드 에러 해결

### Issue

-   resolves: #29 


# 📋 작업 내용

-   TypeScript에서 optional 속성(?)은 값이 없을 때 `undefined`를 반환한다는 점에서, `null` 대신 `undefined`를 사용하는 것이 더 직관적이고 간결하다고 판단했습니다.

- 이에 따라 빈 값을 모두 `undefined`로 통일했습니다.