### PR TITLE
[Refactor] 검색 시 batch 방식 적용 및 최적화

### DIFF
--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -115,7 +115,6 @@ export class FeedService {
 
   async searchFeedList(searchFeedReq: SearchFeedReq) {
     const { find, page, limit, type, cursor } = searchFeedReq;
-    console.log(cursor);
     if (this.validateSearchType(type)) {
       const [result, totalCount, nextCursor] =
         await this.feedRepository.searchFeedList(


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   resolves: #27 

### batch 방식 적용

**목적**
- cursor를 통해 응답 속도를 개선하고자 했던 기존 방식은 cursor 데이터가 존재하지 않는 1페이지에선 전혀 효용성이 없는 방식이었습니다. 또한 검색 시 첫 페이지가 나오는 속도는 사용자가 검색 속도에 대해 가장 크게 느낄 수 있는 부분이기에 이에 대한 추가적인 개선을 하고자 하였습니다.

**고민했던 사항**
- 첫 페이지를 가져오는데 오랜 시간이 걸리는 이유와 개선 방향
  현재 `like` 연산자를 통해 제목 및 블로거를 탐색합니다. 그러나 데이터 셋이 큰 경우 이에 대한 연산에 시간을 많이 사용한다는 생각을 했습니다.
  해당 문제를 개선하기 위해 feed 데이터를 인덱스 처리가 되어 있는 createdAt column을 통해 최신순 정렬을 한 후, batch라는 작은 데이터 덩어리를 가져와 탐색하고자 했습니다.
  이는 첫 페이지의 limit(현재 : 5) 값 만큼의 데이터만이 필요하기에 작은 데이터셋 탐색을 통해서도 충분히 탐색이 가능했기 때문입니다. 따라서 기존 방식(전체 데이터를 순회하여 필터에 포함되는 모든 데이터를 탐색 후 원하는 크기만 가져오는 방식)의 비효율성을 개선할 수 있습니다.

  실제로 검색 필터의 포함된 데이터들이 최신순 정렬 시 상단에 위치하는 경우 아래 테스트 결과와 같이 8.20s⇒5.68s로 감소(약 30.7% 속도 개선) 상당히 높은 개선률을 확인할 수 있었습니다.

- 테스트 결과
  ![image](https://github.com/user-attachments/assets/93c806a8-1481-47a9-8b14-da96a7843e41)

  ![image](https://github.com/user-attachments/assets/94d7365f-ce1d-414c-82e7-d6f2ecc0f20d)


### batch 적용 시의 최악의 상황

- 위의 개선 테스트 결과는 검색 필터의 포함된 데이터들이 최신순 정렬 시 상단에 위치하는, 개선의 결과를 가장 잘 보여주는 테스트 경우였습니다.
- 그러나 전체 데이터 셋이 매우 크고 그 중에서도 첫 페이지에 필요로 하는 데이터가 하단에 위치하는 최악의 경우, 기존 방식에서 네트워킹 오버헤드와 count, skip/take 등 재연산이 많아서 오히려 오래걸릴 수 있습니다. 아래 테스트는 40분이 넘는 응답 시간을 보이며 실 서비스에서 사용할 수 없는 단점을 보였습니다.

- 최악의 경우 테스트 결과
  ![image](https://github.com/user-attachments/assets/6ff98b27-96aa-4c4d-9d2e-6c1ac6fdff48)

### batch 부분 적용

**batch 적용의 장단점**
- 최선의 상황에선 약 30%의 시간을 절약하는 개선 성능을 볼 수 있었습니다.
- 최악의 상황을 확인 시 응답 시간이 비정상적으로 길어짐을 확인 했으나, 해당 테스트는 일부러 데이터를 찾기 위해 1000번의 탐색이 필요하도록 조정 한 것입니다. 더하여 최선의 상황을 확인 했을 때 시간 절약 관점에서 큰 이득을 볼 수 있습니다.

- 그럼에도 불구하고 해당 탐색에 40분이 넘는 시간이 걸리는 것은 묵과할 수 없는 큰 오류 사항이므로 Promise.race를 사용하여 기존 방식이 더 빠르게 탐색을 마친 경우 해당 결과를 반환하도록 batch 방식의 부분 적용을 진행했습니다.

=> 부분 적용 이후 똑같은 최악의 경우를 테스트한 결과, 비정상적으로 긴 응답 시간은 가지지 않는 것을 확인했습니다.
      ![image](https://github.com/user-attachments/assets/8a0a5805-5368-464f-97a7-682fb5e0f9c7)


# 📋 작업 내용

- batch 방식 부분 적용
- Promise.race를 통해 더 빠른 응답을 찾아 반환
- abort Controller를 사용하여 batch방식이 더 느릴 경우 중단
