### PR TITLE
[Feat] 포스트 카드에 태그 목록 추가 기능 구현

### DIFF
--- a/client/src/components/common/Card/PostCardContent.tsx
+++ b/client/src/components/common/Card/PostCardContent.tsx
@@ -5,6 +5,7 @@ import { CardContent } from "@/components/ui/card";
 
 import { formatDate } from "@/utils/date";
 
+import { PostCardTags } from "./PostCardTags";
 import { Post } from "@/types/post";
 
 interface PostCardContentProps {
@@ -15,6 +16,7 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
   const [isValidImage, setIsValidImage] = useState<boolean>(true);
   const authorInitial = post.author?.charAt(0)?.toUpperCase() || "?";
   const data = `https://denamu.site/files/${post.blogPlatform}-icon.svg`;
+
   return (
     <CardContent className="p-0">
       <div className="relative -mt-6 ml-4 mb-3">
@@ -38,7 +40,10 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
         <p className="h-[40px] font-bold text-sm group-hover:text-primary transition-colors line-clamp-2">
           {post.title}
         </p>
-        <p className="text-[10px] text-gray-400 pt-2">{formatDate(post.createdAt)}</p>
+        <div className="flex justify-between items-center pt-2">
+          <p className="text-[10px] text-gray-400">{formatDate(post.createdAt)}</p>
+          <PostCardTags tags={post.tags} />
+        </div>
       </div>
     </CardContent>
   );

--- a/client/src/components/common/Card/PostCardTags.tsx
+++ b/client/src/components/common/Card/PostCardTags.tsx
@@ -1,0 +1,17 @@
+interface PostCardTagsProps {
+  tags?: string[];
+}
+
+export const PostCardTags = ({ tags }: PostCardTagsProps) => {
+  if (!tags || tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1 justify-end">
+      {tags.map((tag) => (
+        <span key={tag} className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-md text-xs font-medium">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
# 🔨태스크

- 블로그 포스트 카드 컴포넌트의 태그 표시 기능을 구현하였습니다.

### Issue

-   resolves: #41 

# 📋 작업 내용

### PostCardTags 컴포넌트 구현 (`/components/common/Card/PostCardTags.tsx`)
* 포스트의 태그 배열을 받아 태그 목록을 렌더링하는 컴포넌트를 구현하였습니다.
* 태그가 없는 경우 null을 반환하도록 처리하였습니다.

```typescript
export const PostCardTags = ({ tags }: PostCardTagsProps) => {
  if (!tags || tags.length === 0) return null;

  return (
    <div className="flex flex-wrap gap-1 justify-end">
      {tags.map((tag) => (
        <span key={tag} className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-md text-xs font-medium">
          {tag}
        </span>
      ))}
    </div>
  );
};
```

### PostCardContent 컴포넌트 수정 (`/components/common/Card/PostCardContent.tsx`)
* 날짜와 태그 목록을 같은 줄에 배치하도록 레이아웃을 조정하였습니다.
* 날짜는 좌측, 태그 목록은 우측에 정렬되도록 구현하였습니다.

```typescript
<div className="flex justify-between items-center pt-2">
  <p className="text-[10px] text-gray-400">{formatDate(post.createdAt)}</p>
  <PostCardTags tags={post.tags} />
</div>
```

# 📷 스크린 샷(선택 사항)

위치 조정과 디자인을 위해 디폴트로 띄워봤습니다. 지금은 실제 태그 데이터만 띄워주도록 수정해주었습니다.

![스크린샷 2025-02-11 오전 12 33 17](https://github.com/user-attachments/assets/813c7a73-674d-4bef-9fb4-c0ca7988271e)

