### PR TITLE
[Feat] 검색 필터에 태그 카테고리 추가

### DIFF
--- a/client/src/components/common/Card/PostCardContent.tsx
+++ b/client/src/components/common/Card/PostCardContent.tsx
@@ -5,6 +5,7 @@ import { CardContent } from "@/components/ui/card";
 
 import { formatDate } from "@/utils/date";
 
+import { PostCardTags } from "./PostCardTags";
 import { Post } from "@/types/post";
 
 interface PostCardContentProps {
@@ -15,6 +16,7 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
   const [isValidImage, setIsValidImage] = useState<boolean>(true);
   const authorInitial = post.author?.charAt(0)?.toUpperCase() || "?";
   const data = `https://denamu.site/files/${post.blogPlatform}-icon.svg`;
+
   return (
     <CardContent className="p-0">
       <div className="relative -mt-6 ml-4 mb-3">
@@ -38,7 +40,10 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
         <p className="h-[40px] font-bold text-sm group-hover:text-primary transition-colors line-clamp-2">
           {post.title}
         </p>
-        <p className="text-[10px] text-gray-400 pt-2">{formatDate(post.createdAt)}</p>
+        <div className="flex justify-between items-center pt-2">
+          <p className="text-[10px] text-gray-400">{formatDate(post.createdAt)}</p>
+          <PostCardTags tags={post.tags} />
+        </div>
       </div>
     </CardContent>
   );

--- a/client/src/components/common/Card/PostCardTags.tsx
+++ b/client/src/components/common/Card/PostCardTags.tsx
@@ -1,0 +1,17 @@
+interface PostCardTagsProps {
+  tags?: string[];
+}
+
+export const PostCardTags = ({ tags }: PostCardTagsProps) => {
+  if (!tags || tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1 justify-end">
+      {tags.map((tag) => (
+        <span key={tag} className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-md text-xs font-medium">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/client/src/components/search/SearchFilters/FilterButton.tsx
+++ b/client/src/components/search/SearchFilters/FilterButton.tsx
@@ -1,4 +1,4 @@
-import { FileText, User, PanelBottom } from "lucide-react";
+import { FileText, User, PanelBottom, Tag } from "lucide-react";
 
 import { CommandGroup } from "@/components/ui/command";
 
@@ -18,6 +18,7 @@ export default function FilterButton() {
     { label: "제목", filter: "title", icon: <FileText size={16} /> },
     { label: "블로거", filter: "blogName", icon: <User size={16} /> },
     { label: "블로거 + 제목", filter: "all", icon: <PanelBottom size={16} /> },
+    { label: "태그", filter: "tags", icon: <Tag size={16} /> },
   ];
 
   const getItemClassName = (isActive: boolean) =>

--- a/client/src/components/search/SearchFilters/FilterButton.tsx
+++ b/client/src/components/search/SearchFilters/FilterButton.tsx
@@ -18,7 +18,7 @@ export default function FilterButton() {
     { label: "제목", filter: "title", icon: <FileText size={16} /> },
     { label: "블로거", filter: "blogName", icon: <User size={16} /> },
     { label: "블로거 + 제목", filter: "all", icon: <PanelBottom size={16} /> },
-    { label: "태그", filter: "tags", icon: <Tag size={16} /> },
+    { label: "태그", filter: "tag", icon: <Tag size={16} /> },
   ];
 
   const getItemClassName = (isActive: boolean) =>

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -39,4 +39,4 @@ export interface SearchRequest {
   cursor?: CursorData;
 }
 
-export type FilterType = "title" | "blogName" | "all";
+export type FilterType = "title" | "blogName" | "all" | "tags";

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -39,4 +39,4 @@ export interface SearchRequest {
   cursor?: CursorData;
 }
 
-export type FilterType = "title" | "blogName" | "all" | "tags";
+export type FilterType = "title" | "blogName" | "all" | "tag";


### PR DESCRIPTION
# 🔨 테스크

- 검색 기능에 태그 필터를 추가하여 사용자가 태그를 기준으로 포스트를 검색할 수 있도록 구현하였습니다.

### Issue

-   resolves: #43 

# 📋 작업 내용

### FilterType 타입 확장 (`/types/search.ts`)

- 기존 필터 타입에 "tags" 타입을 추가하였습니다.

```typescript
export type FilterType = "title" | "blogName" | "all" | "tag";
```

### 검색 필터 UI 구현 (`/components/search/SearchFilters/FilterButton.tsx`)

- 기존 필터 옵션 목록에 태그 필터를 추가하였습니다.

```typescript
import { FileText, User, PanelBottom, Tag } from "lucide-react";

const filterOptions: FilterOption[] = [
  { label: "제목", filter: "title", icon: <FileText size={16} /> },
  { label: "블로거", filter: "blogName", icon: <User size={16} /> },
  { label: "블로거 + 제목", filter: "all", icon: <PanelBottom size={16} /> },
  { label: "태그", filter: "tag", icon: <Tag size={16} /> },
];
```

`getSearch` API가 이미 필터 타입을 params로 전달하고 있었던 터라 복잡한 수정이 필요하지 않았습니다. 후딱 추가해보았습니다 !

# 📷 스크린 샷(선택 사항)

![스크린샷 2025-02-11 오전 12 52 58](https://github.com/user-attachments/assets/0559b814-2325-451d-b462-990b68d339f8)
