### PR TITLE
[Feat] 포스트 카드 호버 시에 게시글 소개 툴팁 띄워주기

### DIFF
--- a/client/src/api/services/postDescription.ts
+++ b/client/src/api/services/postDescription.ts
@@ -1,0 +1,32 @@
+import { axiosInstance } from "@/api/instance";
+
+interface PostSummaryResponse {
+  message: string;
+  data: {
+    id: number;
+    summary: string;
+  };
+}
+
+export const postDescription = {
+  getSummary: async (feedId: number): Promise<string> => {
+    try {
+      const response = await axiosInstance.get<PostSummaryResponse>(`/api/feed/ai/summary`, {
+        params: {
+          feedId,
+        },
+      });
+
+      const summary = response.data.data.summary;
+
+      if (summary === "FAILED" || summary === "") {
+        return null;
+      }
+
+      return summary;
+    } catch (error) {
+      console.error("Failed to fetch post summary:", error);
+      return null;
+    }
+  },
+};

--- a/client/src/api/services/postDescription.ts
+++ b/client/src/api/services/postDescription.ts
@@ -9,7 +9,7 @@ interface PostSummaryResponse {
 }
 
 export const postDescription = {
-  getSummary: async (feedId: number): Promise<string> => {
+  getSummary: async (feedId: number): Promise<string | null> => {
     try {
       const response = await axiosInstance.get<PostSummaryResponse>(`/api/feed/ai/summary`, {
         params: {

--- a/client/src/components/common/Card/PostCard.tsx
+++ b/client/src/components/common/Card/PostCard.tsx
@@ -4,6 +4,7 @@ import { usePostCardActions } from "@/hooks/common/usePostCardActions";
 
 import { PostCardContent } from "./PostCardContent";
 import { PostCardImage } from "./PostCardImage";
+import { PostDescription } from "./PostDescription";
 import { cn } from "@/lib/utils";
 import { Post } from "@/types/post";
 
@@ -16,15 +17,17 @@ export const PostCard = ({ post, className }: PostCardProps) => {
   const { handlePostClick } = usePostCardActions(post);
 
   return (
-    <Card
-      onClick={handlePostClick}
-      className={cn(
-        "h-[240px] group shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer",
-        className
-      )}
-    >
-      <PostCardImage thumbnail={post.thumbnail} alt={post.title} />
-      <PostCardContent post={post} />
-    </Card>
+    <PostDescription postId={post.id}>
+      <Card
+        onClick={handlePostClick}
+        className={cn(
+          "h-[240px] group shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer",
+          className
+        )}
+      >
+        <PostCardImage thumbnail={post.thumbnail} alt={post.title} />
+        <PostCardContent post={post} />
+      </Card>
+    </PostDescription>
   );
 };

--- a/client/src/components/common/Card/PostCardContent.tsx
+++ b/client/src/components/common/Card/PostCardContent.tsx
@@ -5,6 +5,7 @@ import { CardContent } from "@/components/ui/card";
 
 import { formatDate } from "@/utils/date";
 
+import { PostCardTags } from "./PostCardTags";
 import { Post } from "@/types/post";
 
 interface PostCardContentProps {
@@ -15,6 +16,7 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
   const [isValidImage, setIsValidImage] = useState<boolean>(true);
   const authorInitial = post.author?.charAt(0)?.toUpperCase() || "?";
   const data = `https://denamu.site/files/${post.blogPlatform}-icon.svg`;
+
   return (
     <CardContent className="p-0">
       <div className="relative -mt-6 ml-4 mb-3">
@@ -38,7 +40,10 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
         <p className="h-[40px] font-bold text-sm group-hover:text-primary transition-colors line-clamp-2">
           {post.title}
         </p>
-        <p className="text-[10px] text-gray-400 pt-2">{formatDate(post.createdAt)}</p>
+        <div className="flex justify-between items-center pt-2">
+          <p className="text-[10px] text-gray-400">{formatDate(post.createdAt)}</p>
+          <PostCardTags tags={post.tags} />
+        </div>
       </div>
     </CardContent>
   );

--- a/client/src/components/common/Card/PostCardTags.tsx
+++ b/client/src/components/common/Card/PostCardTags.tsx
@@ -1,0 +1,17 @@
+interface PostCardTagsProps {
+  tags?: string[];
+}
+
+export const PostCardTags = ({ tags }: PostCardTagsProps) => {
+  if (!tags || tags.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1 justify-end">
+      {tags.map((tag) => (
+        <span key={tag} className="px-2 py-0.5 bg-gray-100 text-gray-600 rounded-md text-xs font-medium">
+          {tag}
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/client/src/components/common/Card/PostDescription.tsx
+++ b/client/src/components/common/Card/PostDescription.tsx
@@ -1,0 +1,90 @@
+import React, { useState, useRef, useCallback } from "react";
+
+import { Loader2 } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+import { postDescription } from "@/api/services/postDescription";
+
+interface PostDescriptionProps {
+  postId: number;
+  children: React.ReactNode;
+}
+
+const Spinner = () => {
+  return <Loader2 className="h-4 w-4 animate-spin text-primary" />;
+};
+
+export const PostDescription = ({ postId, children }: PostDescriptionProps) => {
+  const [description, setDescription] = useState<string | null>(null);
+  const [isHovering, setIsHovering] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasRequested, setHasRequested] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    setIsHovering(true);
+    setIsLoading(true);
+
+    if (hasRequested) {
+      setIsLoading(false);
+      return;
+    }
+
+    timerRef.current = setTimeout(async () => {
+      const summary = await postDescription.getSummary(postId);
+      setDescription(summary);
+      setIsLoading(false);
+      setHasRequested(true);
+    }, 1000);
+  }, [postId, hasRequested]);
+
+  const handleMouseLeave = useCallback(() => {
+    setIsHovering(false);
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (!hasRequested) {
+      setIsLoading(false);
+    }
+  }, [hasRequested]);
+
+  const getTooltipContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex items-center gap-2 py-1">
+          <Spinner />
+          <p className="text-sm text-foreground">요약을 불러오는 중입니다...</p>
+        </div>
+      );
+    }
+
+    if (description === null && hasRequested) {
+      return (
+        <div className="py-1">
+          <p className="text-sm text-muted-foreground">게시글 요약을 제공할 수 없습니다.</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="py-1">
+        <p className="text-sm text-foreground leading-relaxed">{description}</p>
+      </div>
+    );
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip open={isHovering}>
+        <TooltipTrigger onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} className="w-full">
+          {children}
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[300px] p-3 shadow-lg bg-background border-border" sideOffset={5}>
+          {getTooltipContent()}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/client/src/components/common/Card/PostDescription.tsx
+++ b/client/src/components/common/Card/PostDescription.tsx
@@ -68,6 +68,14 @@ export const PostDescription = ({ postId, children }: PostDescriptionProps) => {
       );
     }
 
+    if (description === "" && hasRequested) {
+      return (
+        <div className="py-1">
+          <p className="text-sm text-muted-foreground">게시글의 길이가 짧아서 요약이 제공되지 않습니다.</p>
+        </div>
+      );
+    }
+
     return (
       <div className="py-1">
         <p className="text-sm text-foreground leading-relaxed">{description}</p>

--- a/client/src/components/search/SearchFilters/FilterButton.tsx
+++ b/client/src/components/search/SearchFilters/FilterButton.tsx
@@ -1,4 +1,4 @@
-import { FileText, User, PanelBottom } from "lucide-react";
+import { FileText, User, PanelBottom, Tag } from "lucide-react";
 
 import { CommandGroup } from "@/components/ui/command";
 
@@ -18,6 +18,7 @@ export default function FilterButton() {
     { label: "제목", filter: "title", icon: <FileText size={16} /> },
     { label: "블로거", filter: "blogName", icon: <User size={16} /> },
     { label: "블로거 + 제목", filter: "all", icon: <PanelBottom size={16} /> },
+    { label: "태그", filter: "tags", icon: <Tag size={16} /> },
   ];
 
   const getItemClassName = (isActive: boolean) =>

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -39,4 +39,4 @@ export interface SearchRequest {
   cursor?: CursorData;
 }
 
-export type FilterType = "title" | "blogName" | "all";
+export type FilterType = "title" | "blogName" | "all" | "tags";


### PR DESCRIPTION
# 🔨 태스크
* 게시글 요약 정보 툴팁 기능 구현
* 호버 시 요약 정보 API 연동

### Issue
* resolves: #45 

# 📋 작업 내용

### 게시글 요약 정보 컴포넌트 구현 (`/components/common/Card/PostDescription.tsx`)

* 게시글 카드에 마우스 호버 시 요약 정보를 보여주는 툴팁 컴포넌트를 구현하였습니다.
* 호버 즉시 로딩 상태를 표시하고, 1초 후 요약 정보를 요청하도록 구현하였습니다.
* 마우스가 떠날 경우 타이머와 로딩 상태를 초기화하도록 하였습니다.
* 같은 카드에 대한 요약 정보는 저장해두었다가 재사용하도록 했습니다.

### 요약 정보 API 서비스 구현 (`/api/services/postDescription.ts`)
* 게시글 요약 정보를 가져오는 API 서비스를 구현하였습니다.
* 명세에 맞춰 요약 정보가 없거나 실패한 경우("FAILED" 또는 빈 문자열)에 대한 처리를 추가하였습니다.


### 게시글 카드 컴포넌트 수정 (`/components/common/Card/PostCard.tsx`)
* 기존 `PostCard` 컴포넌트에 `PostDescription` 컴포넌트를 적용하였습니다.
* 게시글 카드 전체를 `PostDescription`으로 감싸 호버 시 요약 정보가 표시되도록 구현하였습니다.


# 📷 스크린 샷(선택 사항)


https://github.com/user-attachments/assets/53e9ec36-7302-4026-b16d-daee8fedc98e

