### PR TITLE
[Feat] 태그 검색 기능 추가

### DIFF
--- a/server/src/feed/dto/search-feed.dto.ts
+++ b/server/src/feed/dto/search-feed.dto.ts
@@ -15,6 +15,7 @@ export enum SearchType {
   TITLE = 'title',
   BLOGNAME = 'blogName',
   ALL = 'all',
+  TAG = 'tag',
 }
 
 export class FeedIndex {

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -144,6 +144,7 @@ export class FeedService {
     const searchType = {
       title: 'title',
       blogName: 'blogName',
+      tag: 'tag',
       all: 'all',
     };
 

--- a/server/src/tag/tag.entity.ts
+++ b/server/src/tag/tag.entity.ts
@@ -1,4 +1,10 @@
-import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  ManyToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Feed } from '../feed/feed.entity';
 
 @Entity()
@@ -7,6 +13,7 @@ export class Tag {
   id: number;
 
   @Column()
+  @Index()
   name: string;
 
   @ManyToMany(() => Feed, (feed) => feed.tags)


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #48

# 📋 작업 내용

### 태그 검색 기능 추가
- AI 기능 추가로 태그 자동 설정 기능을 활용하기 위한 태그로 게시글 검색 기능 추가
- 기존 검색 기능을 유지한 상태로 태그 타입만 추가

## 구현
- 기존 검색창에서 태그로 검색 기능 추가
- 검색 결과에 태그가 포함되지 않고, 기존 검색 결과 반환값과 동일하게 반환해야 한다.

### 기존 API 명세
![image](https://github.com/user-attachments/assets/c3da489f-3542-4a7f-b575-00c7ce1749e8)

### 기존 코드
```js
// Controller
@Get('search')
  async searchFeedList(@Query() searchFeedReq: SearchFeedReq) {
    const data = await this.feedService.searchFeedList(searchFeedReq);
    return ApiResponse.responseWithData('검색 결과 조회 완료', data);
  }

// Service
  async searchFeedList(searchFeedReq: SearchFeedReq) {
    const { find, page, limit, type, cursor } = searchFeedReq;
    if (this.validateSearchType(type)) {
      const [result, totalCount, nextCursor] =
        await this.feedRepository.searchFeedList(
          find,
          limit,
          type,
          page,
          cursor,
        );

      const results = SearchFeedResult.feedsToResults(result);
      const totalPages = Math.ceil(totalCount / limit);
      return new SearchFeedRes(
        totalCount,
        results,
        totalPages,
        limit,
        nextCursor,
      );
    }
    throw new BadRequestException('검색 타입이 잘못되었습니다.');
  }

// Repository
  async searchFeedList(
    find: string,
    limit: number,
    type: SearchType,
    page: number,
    cursor?: Cursor,
  ): Promise<[Feed[], number, Cursor]> {
    if (page === 1) {
      const abortControllerForBatch = new AbortController();
      const result = await Promise.race([
        this.searchFeedListByStandard(find, limit, type, page, cursor),
        this.searchFeedListByBatch(
          find,
          limit,
          type,
          page,
          abortControllerForBatch,
        ),
      ]);
      abortControllerForBatch.abort();
      return result;
    }
    return this.searchFeedListByStandard(find, limit, type, page, cursor);
  }
```
---
### 수정 내용
- SearchFeedReq에서 SearchType에 tag 추가
- validateSearchType 수정
```js
export enum SearchType {
  TITLE = 'title',
  BLOGNAME = 'blogName',
  ALL = 'all',
  TAG = 'tag',
}

  private validateSearchType(type: string) {
    const searchType = {
      title: 'title',
      blogName: 'blogName',
      tag: 'tag',
      all: 'all',
    };

    return searchType.hasOwnProperty(type);
  }
```

- FeedRepository 수정
```js
// FeedRepository 메서드 중
    const queryBuilder = this.createQueryBuilder('feed').innerJoinAndSelect(
      'feed.blog',
      'rss_accept',
    );

    if (type === 'tag') {
      queryBuilder.innerJoin('feed.tags', 'tag');
    }

    queryBuilder
      .where(this.getWhereCondition(type), { find: `%${find}%` })
      .orderBy('feed.createdAt', 'DESC')
      .skip(offset)
      .take(limit);

...

  private getWhereCondition(type: string): string {
    switch (type) {
      case 'title':
        return 'feed.title LIKE :find';
      case 'blogName':
        return 'rss_accept.name LIKE :find';
      case 'all':
        return '(feed.title LIKE :find OR rss_accept.name LIKE :find)';
      case 'tag':
        return 'tag.name LIKE :find';
    }
  }

```
- searchFeedListByStandard(), searchFeedListByBatch() 두가지 함수에서 조회 쿼리 수정
- tag 테이블을 조인한 뒤 getWhereCondition에서 tag 타입 처리 로직 추가

