### PR TITLE
[Feat] summary 로직 수정 및 feed summary 조회 api 구현

### DIFF
--- a/server/src/ai/ai.config.ts
+++ b/server/src/ai/ai.config.ts
@@ -31,13 +31,13 @@ export const AISummaryConfig = (
   PROMPT: {
     role: 'system',
     content: `- 당신은 반드시 ${summaryMaxLength} 글자 미만의 요약을 제공하는 텍스트 요약 어시스턴트입니다.
-  - 주어진 XML 형태의 텍스트를 분석하고 핵심 주제를 추출합니다.
-  - 이 글에 대한 요약은 해당 글을 홍보하고자 하는 목적으로 사용되며, 내부 내용에 대한 상세 사항은 응답에 포함되면 안됩니다.
+  - 주어진 텍스트를 분석하고 핵심 주제를 추출하여 요약합니다.
+  - 요약은 해당 글을 홍보하고자 하는 목적으로 사용되며, 내부 내용에 대한 상세 사항은 응답에 포함되면 안됩니다.
   - 답변 형태 : ~~~한 주제에 대해 다루고 있는 포스트입니다.`,
   },
   TOPP: 0.6,
   TOPK: 0,
-  MAXTOKENS: 35,
+  MAXTOKENS: 120,
   TEMPERATURE: 0.1,
   REPEATPENALTY: 2.0,
   STOPBEFORE: [],

--- a/server/src/ai/ai.config.ts
+++ b/server/src/ai/ai.config.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 
 export interface AIConfig {
+  MIN_CONTENT_LENGTH: number;
   API_KEY: string;
   CLOVASTUDIO_REQUEST_ID: string;
   URL: URL;
@@ -21,7 +22,9 @@ export interface AIConfig {
 export const AISummaryConfig = (
   configService: ConfigService,
   summaryMaxLength: number,
+  summaryContentMinLength: number,
 ): AIConfig => ({
+  MIN_CONTENT_LENGTH: summaryContentMinLength,
   API_KEY: configService.get<string>('API_KEY'),
   CLOVASTUDIO_REQUEST_ID: configService.get<string>(
     'CLOVASTUDIO_REQUEST_ID_SUMMARY',

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -8,18 +8,15 @@ export enum AIType {
 }
 
 const contentMaxLength = 7600;
+const summaryMaxLength = 120;
 
 @Injectable()
 export class AIService {
   private summaryConfig: AIConfig;
   static reReqCount = 5;
-  static summaryMaxLength = 120;
 
   constructor(private readonly configService: ConfigService) {
-    this.summaryConfig = AISummaryConfig(
-      this.configService,
-      AIService.summaryMaxLength,
-    );
+    this.summaryConfig = AISummaryConfig(this.configService, summaryMaxLength);
   }
 
   getConfigByType(type: AIType) {
@@ -59,16 +56,15 @@ export class AIService {
     };
   }
 
-  cutContent(feedData: String) {
-    return feedData.length < contentMaxLength
-      ? feedData
-      : feedData.substring(0, contentMaxLength);
+  cutContent(feedData: string, length: number) {
+    return feedData.length < length ? feedData : feedData.substring(0, length);
   }
 
-  async postAIReq(type: AIType, feedData: String) {
+  async postAIReq(type: AIType, feedData: string) {
     try {
       const AIConfig = this.getConfigByType(type);
-      const cutData = this.cutContent(feedData);
+      const cutData = this.cutContent(feedData, contentMaxLength);
+      console.log('count: ' + cutData.length);
       const body = this.getBody(type, cutData);
       let count = 0;
       let resLength = -1;
@@ -98,20 +94,21 @@ export class AIService {
         result = await this.filterResponse(type, response);
         resLength = result.length;
         count++;
+        console.log('summary: ' + result);
       }
       if (resLength > AIConfig.LIMITLENGTH || resLength <= 0) {
-        result = '요약 데이터가 유효하지 않습니다.';
+        throw new Error('유효하지 않은 응답 데이터입니다.');
       }
       return result;
     } catch (error) {
       console.error('에러 발생:', error);
-      return '';
+      return 'FAILED';
     }
   }
 
-  filterResponse(type: AIType, response: Response) {
+  async filterResponse(type: AIType, response: Response) {
     if (type == AIType.Summary) {
-      return this.summaryResFilter(response);
+      return await this.summaryResFilter(response);
     }
     return '';
   }
@@ -124,20 +121,20 @@ export class AIService {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-
       const chunk = decoder.decode(value, { stream: true });
       const isResult = chunk.match(/event:result/g);
       if (!isResult) continue;
       const dataMatches = chunk.match(/\"message\":\s*(\{.*?\})/g);
-
       if (dataMatches) {
         dataMatches.forEach((data) => {
           try {
             const jsonString = data.replace('"message":', '').trim();
             const parsedData = JSON.parse(jsonString);
             if (parsedData.content) {
-              accumulatedText = parsedData.content.trim();
-
+              accumulatedText = this.cutContent(
+                parsedData.content.trim(),
+                summaryMaxLength,
+              );
               const lastDotIndex = accumulatedText.lastIndexOf('.');
               accumulatedText = accumulatedText.substring(0, lastDotIndex + 1);
             }

--- a/server/src/feed/api-docs/getFeedSummary.api-docs.ts
+++ b/server/src/feed/api-docs/getFeedSummary.api-docs.ts
@@ -1,0 +1,36 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+
+export function ApiGetFeedSummary() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '피드 홍보용 요약글 조회 API',
+    }),
+    ApiOkResponse({
+      description: 'Ok',
+      schema: {
+        properties: {
+          message: {
+            type: 'string',
+          },
+          data: {
+            type: 'object',
+            properties: {
+              id: { type: 'number' },
+              summary: { type: 'string' },
+            },
+          },
+        },
+      },
+      example: {
+        message: '요약 조회 완료',
+        data: [
+          {
+            id: 1,
+            summary: '~~~에 대해 설명하는 포스트입니다.',
+          },
+        ],
+      },
+    }),
+  );
+}

--- a/server/src/feed/feed.controller.ts
+++ b/server/src/feed/feed.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  ParseIntPipe,
   Post,
   Query,
   Req,
@@ -110,5 +111,15 @@ export class FeedController {
       '최신 피드 업데이트 완료',
       await this.feedService.readRecentFeedList(),
     );
+  }
+
+  @Get('/ai/summary')
+  @HttpCode(HttpStatus.OK)
+  async getFeedSummary(@Query('feedId', ParseIntPipe) feedId: number) {
+    const summary = await this.feedService.getFeedSummary(feedId);
+    return ApiResponse.responseWithData('요약 조회 완료', {
+      id: feedId,
+      summary,
+    });
   }
 }

--- a/server/src/feed/feed.controller.ts
+++ b/server/src/feed/feed.controller.ts
@@ -27,6 +27,7 @@ import { ApiSearchFeedList } from './api-docs/searchFeedList.api-docs';
 import { ApiUpdateFeedViewCount } from './api-docs/updateFeedViewCount.api-docs';
 import { ApiReadRecentFeedList } from './api-docs/readRecentFeedList.api-docs';
 import { Feed } from './feed.entity';
+import { ApiGetFeedSummary } from './api-docs/getFeedSummary.api-docs';
 
 @ApiTags('Feed')
 @Controller('feed')
@@ -113,6 +114,7 @@ export class FeedController {
     );
   }
 
+  @ApiGetFeedSummary()
   @Get('/ai/summary')
   @HttpCode(HttpStatus.OK)
   async getFeedSummary(@Query('feedId', ParseIntPipe) feedId: number) {

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -255,4 +255,12 @@ export class FeedService {
 
     return request.socket.remoteAddress;
   }
+
+  async getFeedSummary(feedId: number) {
+    const feed = await this.feedRepository.findOne({ where: { id: feedId } });
+    if (!feed) {
+      throw new NotFoundException(`${feedId}번 피드를 찾을 수 없습니다.`);
+    }
+    return feed.summary;
+  }
 }

--- a/server/src/rss/feed-crawler.service.ts
+++ b/server/src/rss/feed-crawler.service.ts
@@ -46,7 +46,10 @@ export class FeedCrawlerService {
     return await Promise.all(
       objFromXml.rss.channel.item.map(async (feed) => {
         const testContent = await this.crawlingFeedContent(feed.link);
-        const summary = this.feedAI.postAIReq(AIType.Summary, testContent);
+        const summary = await this.feedAI.postAIReq(
+          AIType.Summary,
+          testContent,
+        );
         const date = new Date(feed.pubDate);
         const contentLength = this.getContentLength(testContent);
         const formattedDate = date.toISOString().slice(0, 19).replace('T', ' ');

--- a/server/src/rss/feed-crawler.service.ts
+++ b/server/src/rss/feed-crawler.service.ts
@@ -45,13 +45,10 @@ export class FeedCrawlerService {
 
     return await Promise.all(
       objFromXml.rss.channel.item.map(async (feed) => {
-        const testContent = await this.crawlingFeedContent(feed.link);
-        const summary = await this.feedAI.postAIReq(
-          AIType.Summary,
-          testContent,
-        );
+        const content = await this.crawlingFeedContent(feed.link);
+        const summary = await this.feedAI.postAIReq(AIType.Summary, content);
         const date = new Date(feed.pubDate);
-        const contentLength = this.getContentLength(testContent);
+        const contentLength = this.getContentLength(content);
         const formattedDate = date.toISOString().slice(0, 19).replace('T', ' ');
         const thumbnail = await this.rssParser.getThumbnailUrl(feed.link);
         return {

--- a/server/src/rss/feed-crawler.service.ts
+++ b/server/src/rss/feed-crawler.service.ts
@@ -45,16 +45,19 @@ export class FeedCrawlerService {
 
     return await Promise.all(
       objFromXml.rss.channel.item.map(async (feed) => {
-        this.feedAI.postAIReq(AIType.Summary, feed.description);
+        const testContent = await this.crawlingFeedContent(feed.link);
+        const summary = this.feedAI.postAIReq(AIType.Summary, testContent);
         const date = new Date(feed.pubDate);
+        const contentLength = this.getContentLength(testContent);
         const formattedDate = date.toISOString().slice(0, 19).replace('T', ' ');
         const thumbnail = await this.rssParser.getThumbnailUrl(feed.link);
-
         return {
           title: this.rssParser.customUnescape(feed.title),
           path: decodeURIComponent(feed.link),
           thumbnail,
           createdAt: formattedDate,
+          summary,
+          contentLength,
         };
       }),
     );
@@ -72,7 +75,6 @@ export class FeedCrawlerService {
       if (!content) {
         throw new BadRequestException('내용이 비어 있습니다.');
       }
-
       return content;
     } catch (error) {
       throw new BadRequestException(`피드 내용 크롤링 실패: ${error.message}`);

--- a/server/src/rss/rss.service.ts
+++ b/server/src/rss/rss.service.ts
@@ -74,6 +74,8 @@ export class RssService {
         const feeds = await this.feedCrawlerService.loadRssFeeds(
           newRssAccept.rssUrl,
         );
+        //tag 기능이 없어서 빈 배열로 넣었습니다.
+        feeds.forEach((feed) => (feed.tags = []));
         feeds.forEach((feed) => (feed.blog = newRssAccept));
         return [newRssAccept, feeds];
       },

--- a/server/src/rss/rss.service.ts
+++ b/server/src/rss/rss.service.ts
@@ -74,8 +74,6 @@ export class RssService {
         const feeds = await this.feedCrawlerService.loadRssFeeds(
           newRssAccept.rssUrl,
         );
-        //tag 기능이 없어서 빈 배열로 넣었습니다.
-        feeds.forEach((feed) => (feed.tags = []));
         feeds.forEach((feed) => (feed.blog = newRssAccept));
         return [newRssAccept, feeds];
       },


### PR DESCRIPTION
# 🔨 태스크

### Issue

-   resolved: #46 

### summary content

- 기존에 xml로 가져오던 content를 필터링 해주는 crawlingFeedContent를 적용하여 실 텍스트로 요약을 요청하도록 변경
- 이에 맞추어 `XML 형식의 포스트를 요약하라` 에서 `주어진 텍스트를 요약하라`로 프롬프트 변경
- content의 글자 수를 더 명확히 셀 수 있게 됨.

### summary 예외 처리

- content의 최소 글자 수를 넘기지 않는 경우 빈 문자열 반환
- content의 최소 글자 수를 넘기지만, summary를 최대 횟수만큼 재요청 했음에도 유효한 summary가 응답되지 않는 경우 `FAILED` 반환
- 유효한 summary가 나온 경우 summary를 그대로 반환.
- content의 최소 글자 수는 120자로 지정
  - summary의 최대 글자 수가 120자인 상황에서, 요약의 바탕이 될 데이터가 summary보다 작은 것은 요약의 필요성이 낮다는 판단으로 해당 글자 수로 지정함.

### db 저장

- feed table에 summary, content length, tags 저장
- tags는 현 develop 브랜치에 업데이트 되지 않아서, 빈 배열로 저장

### summary 조회 api 구현
- feedId를 query param으로 받아와서 식별
- summary 조회 성공 시 200 OK
- 응답 스키마
``` JSON
{
    "message": "요약 조회 완료",
    "data": {
        "id": number,
        "summary": string
    }
}
```

# 📋 작업 내용

-  summary content를 XML형식이 아니라 구현된 crawlingFeedContent를 적용하여 텍스트 형식으로 입력 받도록 수정
  - 이는 rss accept로 새 feed 데이터를 찾아 저장할 때 실행됨.

- summary 예외 처리
  - content 글자 수 < 최소 글자 수: 빈 문자열
  - content 글자 수 >= 최소 글자 수 && 유효하지 않은 summary: "FAILED"
  - 유효한 summary: `"summary 내용"`

- db에 summary, content length, tags(tag는 빈 배열로) 저장

- summary 조회 api 구현
  - docs도 추가적으로 작성함.

# 📷 스크린 샷(선택 사항)

- content 길이가 너무 적어서 요약이 되지 않은 summary 조회
![image](https://github.com/user-attachments/assets/f347bbd9-12be-4ff3-97c7-a6ffdcd5d64f)

- content 길이는 괜찮지만, 여러 번의 재요청에도 유효한 요약 데이터가 나오지 않은 summary 조회
![image](https://github.com/user-attachments/assets/17561183-1e25-4664-a8f6-60e552d89335)

- 유효한 요약 데이터의 summary 조회
![image](https://github.com/user-attachments/assets/508c21cc-8f12-460e-807c-98b85436a581)

