### PR TITLE
[Feat] AI Tag 기능 구현

### DIFF
--- a/server/src/ai/ai.config.ts
+++ b/server/src/ai/ai.config.ts
@@ -46,3 +46,38 @@ export const AISummaryConfig = (
   STOPBEFORE: [],
   INCLUDEAIFILTERS: true,
 });
+
+export const AITagConfig = (
+  configService: ConfigService,
+  tagMaxLength: number,
+): AIConfig => ({
+  MIN_CONTENT_LENGTH: 10,
+  API_KEY: configService.get<string>('API_KEY'),
+  CLOVASTUDIO_REQUEST_ID: configService.get<string>(
+    'CLOVASTUDIO_REQUEST_ID_TAG',
+  ),
+  URL: configService.get<URL>('CLOVASTUDIO_URL_TAG'),
+  LIMITLENGTH: tagMaxLength,
+  PROMPT: {
+    role: 'system',
+    content: `아래 글에서 핵심 키워드를 3개 이내로 추출해 주세요.
+    
+    [출력 형식]
+    {"tags": ["키워드1", "키워드2", "키워드3"]}
+    
+    [출력 규칙]
+    - 핵심 키워드는 3개 이내로 작성해 주세요.
+    - 각 키워드는 단어 또는 2~3단어의 짧은 구문으로 작성해 주세요.
+    - 중복되는 의미를 가진 키워드는 하나로 통합해 주세요.
+    - 중요도가 동일할 경우 최대 3개의 키워드만 출력하고, 4개 이상 출력하지 않도록 하세요.
+    - 키워드는 중요도 순서대로 나열해 주세요.
+    - 반드시 JSON 형식으로 출력해 주세요.`,
+  },
+  TOPP: 0.8,
+  TOPK: 0,
+  MAXTOKENS: 100,
+  TEMPERATURE: 0.5,
+  REPEATPENALTY: 5.0,
+  STOPBEFORE: [],
+  INCLUDEAIFILTERS: true,
+});

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -1,19 +1,22 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { delay } from 'rxjs/operators';
-import { AIConfig, AISummaryConfig } from './ai.config';
+import { AIConfig, AISummaryConfig, AITagConfig } from './ai.config';
 
 export enum AIType {
   Summary,
+  Tag,
 }
 
 const contentMaxLength = 7600;
 const summaryMaxLength = 120;
 const summaryContentMinLength = 120;
+const tagMaxLength = 100;
 
 @Injectable()
 export class AIService {
   private summaryConfig: AIConfig;
+  private tagConfig: AIConfig;
   static reReqCount = 5;
 
   constructor(private readonly configService: ConfigService) {
@@ -22,10 +25,12 @@ export class AIService {
       summaryMaxLength,
       summaryContentMinLength,
     );
+    this.tagConfig = AITagConfig(this.configService, tagMaxLength);
   }
 
   getConfigByType(type: AIType) {
     if (type == AIType.Summary) return this.summaryConfig;
+    if (type == AIType.Tag) return this.tagConfig;
     else return null;
   }
 
@@ -82,7 +87,7 @@ export class AIService {
       ) {
         const response = await fetch(AIConfig.URL, {
           method: 'POST',
-          headers: this.getHeader(AIType.Summary),
+          headers: this.getHeader(type),
           body: JSON.stringify(body),
         });
 
@@ -118,7 +123,7 @@ export class AIService {
     if (type == AIType.Summary) {
       return await this.summaryResFilter(response);
     }
-    return '';
+    return response;
   }
 
   async summaryResFilter(result: string) {

--- a/server/src/ai/ai.service.ts
+++ b/server/src/ai/ai.service.ts
@@ -123,7 +123,10 @@ export class AIService {
     if (type == AIType.Summary) {
       return await this.summaryResFilter(response);
     }
-    return response;
+    if (type == AIType.Tag) {
+      return response;
+    }
+    return '';
   }
 
   async summaryResFilter(result: string) {

--- a/server/src/feed/dto/feed-response.dto.ts
+++ b/server/src/feed/dto/feed-response.dto.ts
@@ -10,6 +10,7 @@ export class FeedPaginationResponseDto {
     private path: string,
     private createdAt: Date,
     private thumbnail: string,
+    private tags: string[],
     private viewCount: number,
     private isNew: boolean,
   ) {}
@@ -23,6 +24,7 @@ export class FeedPaginationResponseDto {
       feed.path,
       feed.createdAt,
       feed.thumbnail,
+      feed.tags,
       feed.viewCount,
       feed.isNew,
     );

--- a/server/src/feed/feed.entity.ts
+++ b/server/src/feed/feed.entity.ts
@@ -5,6 +5,7 @@ import {
   Entity,
   Index,
   JoinColumn,
+  JoinTable,
   ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
@@ -64,6 +65,11 @@ export class Feed extends BaseEntity {
   blog: RssAccept;
 
   @ManyToMany((type) => Tag, (tag) => tag.feeds)
+  @JoinTable({
+    name: 'feed_tags',
+    joinColumn: { name: 'feed_id', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'tag_id', referencedColumnName: 'id' },
+  })
   tags: Tag[];
 }
 

--- a/server/src/rss/rss.module.ts
+++ b/server/src/rss/rss.module.ts
@@ -11,9 +11,10 @@ import { FeedRepository } from '../feed/feed.repository';
 import { RssParserService } from './rss-parser.service';
 import { EmailModule } from '../common/email/email.module';
 import { AIModule } from '../ai/ai.module';
+import { TagModule } from '../tag/tag.module';
 
 @Module({
-  imports: [EmailModule, AIModule],
+  imports: [EmailModule, AIModule, TagModule],
   controllers: [RssController],
   providers: [
     RssService,

--- a/server/src/tag/tag.module.ts
+++ b/server/src/tag/tag.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { TagService } from './tag.service';
+import { TagRepository } from './tag.repository';
 
 @Module({
-  providers: [TagService]
+  providers: [TagService, TagRepository],
+  exports: [TagService],
 })
 export class TagModule {}

--- a/server/src/tag/tag.repository.ts
+++ b/server/src/tag/tag.repository.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource, Repository } from 'typeorm';
+import { Tag } from './tag.entity';
+
+@Injectable()
+export class TagRepository extends Repository<Tag> {
+  constructor(private dataSource: DataSource) {
+    super(Tag, dataSource.createEntityManager());
+  }
+
+  async findTags(tags: string[]) {
+    return await this.find({
+      where: tags.map((name) => ({ name })),
+    });
+  }
+
+  async createTags(newTagNames: string[]) {
+    const newTags = this.create(newTagNames.map((name) => ({ name })));
+    return await this.save(newTags);
+  }
+}

--- a/server/src/tag/tag.service.ts
+++ b/server/src/tag/tag.service.ts
@@ -1,4 +1,25 @@
 import { Injectable } from '@nestjs/common';
+import { TagRepository } from './tag.repository';
+import { Tag } from './tag.entity';
 
 @Injectable()
-export class TagService {}
+export class TagService {
+  constructor(private readonly tagRepository: TagRepository) {}
+
+  async getTags(AITags: string): Promise<Tag[]> {
+    const tags = JSON.parse(AITags).tags;
+
+    if (!tags || tags.length === 0) return [];
+
+    const existingTags = await this.tagRepository.findTags(tags);
+
+    const existingTagNames = existingTags.map((tag) => tag.name);
+    const newTagNames = tags.filter(
+      (name: string) => !existingTagNames.includes(name),
+    );
+
+    const newTags = await this.tagRepository.createTags(newTagNames);
+
+    return [...existingTags, ...newTags];
+  }
+}


### PR DESCRIPTION
# 🔨 테스크

<!-- 이슈에 대한 작업이라면 PR과 이슈 연결 -->

### Issue

-   close {#40}

### AI TAG API 구현

- 출력 형식을 `{"tags": ["키워드1", "키워드2", "키워드3"]}`로 하여서 JSON 형식으로 바로 배열로 받을 수 있도록 구현

### TAG 저장

- ai가 선별한 tag 배열을 보고 존재하지 않는 tag만 저장
- tag entity의 name에 index가 있어서 중복으로 저장되지 않음

# 📋 작업 내용

- AI TAG API 구현
- 존재하지 않는 TAG면 저장
- FEED 저장 시 
  - feed와 tags는 ManyToMany 관계여서 중간 테이블을 만들어주기 위해 JoinTable 어노테이션 설정
  - 원래 insert로 feed를 저장했는데 insert는 단순한 값 삽입만 가능하고 ManyToMany 관계를 무시하기 때문에 save로 변경

# 📷 스크린 샷(선택 사항)

![image](https://github.com/user-attachments/assets/7de0b0be-c2a7-4eb5-ac76-dc13c506126a)

